### PR TITLE
Use config to control execution behavior

### DIFF
--- a/base/include/antioch/base/event_loop.h
+++ b/base/include/antioch/base/event_loop.h
@@ -14,9 +14,12 @@
 namespace antioch {
 namespace base {
 
+// forward declaration
+class Service;
+
 class EventLoop {
  public:
-  EventLoop(std::unique_ptr<Config> cfg);
+  EventLoop(Service* service, std::unique_ptr<Config> cfg);
   void run();
 
  private:
@@ -26,8 +29,8 @@ class EventLoop {
   const std::chrono::time_point<std::chrono::system_clock> boot_time;
   std::chrono::time_point<std::chrono::system_clock> tick;
   std::unique_ptr<Config> config;
-  
-  std::vector<antioch::transit_base::Converter*> converters;
+  std::map<antioch::transit_base::TransitAgency, antioch::transit_base::Converter*> converters;
+  Service* service;
 };
 
 }  // namespace base

--- a/base/include/antioch/base/event_loop.h
+++ b/base/include/antioch/base/event_loop.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include <chrono>
-#include <memory>
 #include <vector>
 
 #include <antioch/transit_base/converter.h>
@@ -19,8 +18,10 @@ class Service;
 
 class EventLoop {
  public:
-  EventLoop(Service* service, std::unique_ptr<Config> cfg);
+  EventLoop(Service* service, Config* cfg);
   void run();
+  // special handling to display new station (upon startup) or switch to a new station
+  void display_new();
 
  private:
   void init_from_config(const antioch::base::Config*);
@@ -28,7 +29,7 @@ class EventLoop {
 
   const std::chrono::time_point<std::chrono::system_clock> boot_time;
   std::chrono::time_point<std::chrono::system_clock> tick;
-  std::unique_ptr<Config> config;
+  Config* config;
   std::map<antioch::transit_base::TransitAgency, antioch::transit_base::Converter*> converters;
   Service* service;
 };

--- a/base/include/antioch/base/service.h
+++ b/base/include/antioch/base/service.h
@@ -27,9 +27,13 @@ class Service {
   // TODO: init BT and app listener
   bool late_init();
 
+  // cycle through which of the home stops is displayed to UI
+  void cycle_home_stops();
+
   void stop();
 
-  antioch::transit_base::Station* curr_station_;
+  std::unique_ptr<Config> config;
+  size_t curr_station_ptr_;
   std::unique_ptr<antioch::connectivity::wifi::WifiService> wifi;
   std::unique_ptr<EventLoop> event_loop;
   std::thread looper;

--- a/base/include/antioch/base/service.h
+++ b/base/include/antioch/base/service.h
@@ -16,6 +16,9 @@ class Service {
   void start();
   void spin();
 
+  // for event loop
+  antioch::transit_base::Station curr_station();
+
  private:
   // starts up the graphics interface
   bool gfx_init();
@@ -26,6 +29,7 @@ class Service {
 
   void stop();
 
+  antioch::transit_base::Station* curr_station_;
   std::unique_ptr<antioch::connectivity::wifi::WifiService> wifi;
   std::unique_ptr<EventLoop> event_loop;
   std::thread looper;

--- a/base/src/service.cpp
+++ b/base/src/service.cpp
@@ -25,8 +25,6 @@ void Service::start() {
 }
 
 void Service::spin() {
-  // std::this_thread::sleep_for(std::chrono::seconds(30));
-  // cycle_home_stops();
   looper.join();
 }
 

--- a/base/src/service.cpp
+++ b/base/src/service.cpp
@@ -28,6 +28,10 @@ void Service::spin() {
   looper.join();
 }
 
+antioch::transit_base::Station Service::curr_station() {
+  return *curr_station_;
+}
+
 bool Service::gfx_init() {
   return true;
 }
@@ -73,13 +77,16 @@ bool Service::late_init() {
     std::cerr << "Using default config, exception reading saved config: " << e.what() << std::endl;
     config = std::move(Configerator::default_config());
   }
+  if (config->user_mode == UserMode::HOME_STOP) {
+    curr_station_ = &config->stations[0];
+  }
   try {
     Configerator::write_or_exception(*config);
   } catch (const std::exception& e) {
     std::cerr << "Exception writing config: " << e.what() << std::endl;
   }
 
-  event_loop = std::make_unique<EventLoop>(std::move(config));
+  event_loop = std::make_unique<EventLoop>(this, std::move(config));
   
   return true;
 }

--- a/connectivity/curl/src/transfer.cpp
+++ b/connectivity/curl/src/transfer.cpp
@@ -96,6 +96,7 @@ void _Transfer_Internal::start_transfer(const std::string& url, bool follow_redi
   if (curl_easy_setopt(eh, CURLOPT_ACCEPT_ENCODING, "gzip") != CURLE_OK) {
     throw LibCurlInternalException("curl_easy_setopt encoding failed!");
   }
+  curl_easy_setopt(eh, CURLOPT_VERBOSE, 1L);
   mp->queue_transfer(eh, cb);
 }
 

--- a/sfmtc/common/src/sfmtc_converter.cpp
+++ b/sfmtc/common/src/sfmtc_converter.cpp
@@ -210,6 +210,7 @@ void SfmtcConverter::refresh_cache(const std::chrono::time_point<std::chrono::sy
     std::cerr << "Timed out waiting for SFMTC API fetch!" << std::endl;
     return;
   }
+  std::cout << fetched.size() << std::endl;
   auto converted = convert(fetched);
   cache.swap(converted);
   update_last_fetch(now);


### PR DESCRIPTION
Use stations provided in the config to determine which converters are initialized and which station(s) are displayed. Include (for now unused) functionality to cycle through stations on command. Later to come: a large text of the pretty name will display for at least a couple seconds to signal a change in home stop, followed by a refresh and display of the new info to the screen.