### PR TITLE
collate xx_to_string() outputs

### DIFF
--- a/sfmtc/common/src/sfmtc_converter.cpp
+++ b/sfmtc/common/src/sfmtc_converter.cpp
@@ -181,6 +181,7 @@ std::vector<StationArrivals> SfmtcConverter::convert(const std::string& data) {
           }
         }
       }
+      std::sort(arrival_vec.begin(), arrival_vec.end());
       trains.emplace_back(stations[i], std::move(arrival_vec));
     }
     return trains;

--- a/sfmtc/common/src/station_arrivals.cpp
+++ b/sfmtc/common/src/station_arrivals.cpp
@@ -14,23 +14,49 @@ StationArrivals::StationArrivals(antioch::transit_base::Station station,
 std::string StationArrivals::bart_to_string() const {
   auto now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
   std::stringstream res;
+  int32_t line_id = -1;
+  bool direction = false;
   for (auto& arrival : arrivals_) {
     auto time_mins = (arrival.second - now) / 60;
-    res << sfmtc::bart::BartLine_pretty_name((sfmtc::bart::BartLine)arrival.first.first);
-    res << ": " << time_mins << " mins\n";
+    // collate arrival times by line
+    if (line_id != arrival.first.first || direction != arrival.first.second) {
+      if (line_id != -1) {
+        res << " mins\n";
+      }
+      res << sfmtc::bart::BartLine_pretty_name((sfmtc::bart::BartLine)arrival.first.first) << ": ";
+      line_id = arrival.first.first;
+      direction = arrival.first.second;
+      res << time_mins;
+    } else {
+      res << ", " << time_mins;
+    }
   }
+  res << " mins";
   return res.str();
 }
 
 std::string StationArrivals::muni_to_string() const {
   auto now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
   std::stringstream res;
+  int32_t line_id = -1;
+  bool direction = false;
   for (auto& arrival : arrivals_) {
     auto time_mins = (arrival.second - now) / 60;
-    res << sfmtc::muni::MuniLine_pretty_name((sfmtc::muni::MuniLine)arrival.first.first)
-        << (arrival.first.second ? " Inbound" : " Outbound")
-        << ": " << time_mins << " mins\n";
+    // collate arrival times by line
+    if (line_id != arrival.first.first || direction != arrival.first.second) {
+      if (line_id != -1) {
+        res << " mins\n";
+      }
+      res << sfmtc::muni::MuniLine_pretty_name((sfmtc::muni::MuniLine)arrival.first.first)
+          << (arrival.first.second ? " Inbound" : " Outbound") << ": ";
+      line_id = arrival.first.first;
+      direction = arrival.first.second;
+      res << time_mins;
+    } else {
+      res << ", " << time_mins;
+    }
   }
+  res << " mins";
   return res.str();
 }
 


### PR DESCRIPTION
Before:
```
Converter:
FOLSOM-PACIFIC Inbound: 119 mins
FOLSOM-PACIFIC Inbound: 99 mins
FOLSOM-PACIFIC Inbound: 79 mins
FOLSOM-PACIFIC Inbound: 59 mins
FOLSOM-PACIFIC Inbound: 40 mins
FOLSOM-PACIFIC Inbound: 21 mins
FOLSOM-PACIFIC Inbound: 0 mins
Done run tick
```
After:
```
Converter:
FOLSOM-PACIFIC Inbound: 0, 21, 40, 59, 79, 99, 119 mins
Done run tick
```